### PR TITLE
Altered map-vals to preserve sorted-map types which fixes #11.

### DIFF
--- a/src/plumbing/core.clj
+++ b/src/plumbing/core.clj
@@ -31,10 +31,14 @@
         (persistent! @m-atom#))))
 
 (defn map-vals
-  "Build map k -> (f v) for [k v] in map m"
+  "Build map k -> (f v) for [k v] in map, preserving the initial type"
   [f m]
-  (if (map? m)
+  (cond 
+    (sorted? m)
+    (reduce-kv (fn [out-m k v] (assoc out-m k (f v))) (sorted-map) m)
+    (map? m)
     (persistent! (reduce-kv (fn [out-m k v] (assoc! out-m k (f v))) (transient {}) m))
+    :else
     (for-map [[k v] m] k (f v))))
 
 (defn map-keys

--- a/test/plumbing/core_test.clj
+++ b/test/plumbing/core_test.clj
@@ -29,7 +29,10 @@
   (is (= (map-vals inc {:a 0 :b 0})
          {:a 1 :b 1}))
   (is (= (map-vals inc [[:a 0] [:b 0]])
-         {:a 1 :b 1})))
+         {:a 1 :b 1}))
+  (is (= (map-vals inc (sorted-map :a 0 :b 0))
+         {:a 1 :b 1}))
+  (is (sorted? (map-vals inc (sorted-map :a 0 :b 0)))))
 
 (deftest map-keys-test
   (is (= (map-keys str {:a 1 :b 1})


### PR DESCRIPTION
What kind of performance hit to the base case is acceptable? Here is a rather naive test on a 1000 element map, given the similar standard deviation we can fairly safely compare the mean at a 1.4% performance hit.

``` clojure
user=> (def my-map (zipmap (range 1000) (range 1000)))
user=> (use 'plumbing.core :reload-all)
nil
user=> (bench (map-vals inc my-map))
Evaluation count : 157740 in 60 samples of 2629 calls.
             Execution time mean : 387.318022 µs
    Execution time std-deviation : 40.596982 µs
   Execution time lower quantile : 365.317478 µs ( 2.5%)
   Execution time upper quantile : 513.232116 µs (97.5%)
                   Overhead used : 6.438181 ns

Found 7 outliers in 60 samples (11.6667 %)
  low-severe   2 (3.3333 %)
  low-mild   5 (8.3333 %)
 Variance from outliers : 72.0586 % Variance is severely inflated by outliers
nil
user=> (bench (map-vals2 inc my-map))
Evaluation count : 163440 in 60 samples of 2724 calls.
             Execution time mean : 392.644723 µs
    Execution time std-deviation : 43.625109 µs
   Execution time lower quantile : 365.288296 µs ( 2.5%)
   Execution time upper quantile : 518.739610 µs (97.5%)
                   Overhead used : 6.438181 ns

Found 6 outliers in 60 samples (10.0000 %)
    low-severe   3 (5.0000 %)
    low-mild     3 (5.0000 %)
 Variance from outliers : 73.8134 % Variance is severely inflated by outliers
nil
```
