### PR TITLE
Use `ex-info` over `RuntimeException` to provide more detailed errors

### DIFF
--- a/src/plumbing/fnk/impl.clj
+++ b/src/plumbing/fnk/impl.clj
@@ -41,7 +41,9 @@
   (when-not (map? m)
     (throw (RuntimeException. (format "Expected a map at key-path %s, got type %s" key-path (class m)))))
   (let [[_ v :as p] (find m k)]
-    (when-not p (throw (RuntimeException. (format "Key %s not found in %s" k (keys m)))))
+    (when-not p (throw (ex-info (format "Key %s not found in %s" k (keys m)) {:error :missing-key
+                                                                              :key   k
+                                                                              :map   m})))
     v))
 
 (defn assert-distinct

--- a/src/plumbing/fnk/schema.clj
+++ b/src/plumbing/fnk/schema.clj
@@ -152,7 +152,8 @@
 
 (defn assert-satisfies-schema [input-schema output-schema]
   (let [fails (schema-diff input-schema output-schema)]
-    (when fails (throw (RuntimeException. (str fails))))))
+    (when fails (throw (ex-info (str fails) {:error    :does-not-satisfy-schema
+                                             :failures fails})))))
 
 
 (s/defn ^:always-validate compose-schemata


### PR DESCRIPTION
This commit modifies a few places in the code that were throwing
raw `RuntimeException` instances to prefer `ex-info` instead.  This
way, a map containing detailed error info can also be included,
which allows callers to inspect the exception more intelligently.

The message strings for the exceptions are not changed, and the
resulting exception still inherits from `RuntimeException`, so
this should theoretically be backwards-compatible with the
previous code.
