### PR TITLE
Fixed issues with using fnk in AOT compiled code

### DIFF
--- a/src/plumbing/fnk/schema.clj
+++ b/src/plumbing/fnk/schema.clj
@@ -50,7 +50,7 @@
 
 ;;; Input schemata
 
-(s/defn explicit-schema-key-map
+(macros/defn explicit-schema-key-map
   "Given a possibly-unevaluated map schema, return a map from bare keyword to true
    (for required) or false (for optional)"
   [s] :- {s/Keyword boolean}
@@ -60,7 +60,7 @@
                  [(s/explicit-schema-key k) (s/required-key? k)])))
        (into {})))
 
-(s/defn split-schema-keys
+(macros/defn split-schema-keys
   "Given output of explicit-schema-key-map, split into seq [req opt]."
   [s :- {s/Keyword boolean}] :- [(s/one [s/Keyword] 'required) (s/one [s/Keyword] 'optional)]
   (->> s
@@ -82,7 +82,7 @@
        vals
        (into {})))
 
-(s/defn union-input-schemata :- InputSchema
+(macros/defn union-input-schemata :- InputSchema
   "Returns a minimal input schema schema that entails satisfaction of both s1 and s2"
   [i1 :- InputSchema i2 :- InputSchema]
   (merge-on-with
@@ -99,7 +99,7 @@
        (non-map-union s1 s2)))
    i1 i2))
 
-(s/defn required-toplevel-keys :- [s/Keyword]
+(macros/defn required-toplevel-keys :- [s/Keyword]
   "Which top-level keys are required (i.e., non-false) by this input schema."
   [input-schema :- InputSchema]
   (keep
@@ -122,7 +122,7 @@
 
 ;;; Combining inputs and outputs.
 
-(s/defn schema-diff ;; don't validate since it returns better errors.
+(macros/defn schema-diff ;; don't validate since it returns better errors.
   "Subtract output-schema from input-schema, returning nil if it's possible that an object
    satisfying the output-schema satisfies the input-schema, or otherwise a description
    of the part(s) of input-schema not met by output-schema.  Strict about the map structure
@@ -156,7 +156,7 @@
                                              :failures fails})))))
 
 
-(s/defn ^:always-validate compose-schemata
+(macros/defn ^:always-validate compose-schemata
   "Given pairs of input and output schemata for fnks f1 and f2,
    return a pair of input and output schemata for #(f2 (merge % (f1 %))).
    f1's output schema must not contain any optional keys."
@@ -178,7 +178,7 @@
 (defn possibly-contains? [m k]
   (boolean (schema-key m k)))
 
-(s/defn split-schema
+(macros/defn split-schema
   "Return a pair [ks-part non-ks-part], with any extra schema removed."
   [s :- InputSchema ks :- [s/Keyword]]
   (let [ks (set ks)]
@@ -188,7 +188,7 @@
                                 (= in? (contains? ks (s/explicit-schema-key k))))]
                  [k v])))))
 
-(s/defn sequence-schemata :- GraphIOSchemata
+(macros/defn sequence-schemata :- GraphIOSchemata
   "Given pairs of input and output schemata for fnks f1 and f2, and a keyword k,
    return a pair of input and output schemata for #(let [v1 (f1 %)] (assoc v1 k (f2 (merge-disjoint % v1))))"
   [[i1 o1] :- GraphIOSchemata


### PR DESCRIPTION
In using fnk from AOT compiled code here: https://github.com/cprice404/puppetdb/blob/maint/master/upgrade-to-tk0.3/src/com/puppetlabs/puppetdb/cli/services.clj#L343 using fnk via: https://github.com/puppetlabs/trapperkeeper/blob/master/src/puppetlabs/trapperkeeper/services.clj#L71 we would see errors like:

```
    Exception in thread "main" java.lang.RuntimeException: No such var: s/defn, compiling (plumbing/fnk/schema.clj:53:1)
    at clojure.lang.Compiler.analyze(Compiler.java:6380)
    at clojure.lang.Compiler.analyze(Compiler.java:6322)
    at clojure.lang.Compiler$InvokeExpr.parse(Compiler.java:3573)
    at clojure.lang.Compiler.analyzeSeq(Compiler.java:6562)
    at clojure.lang.Compiler.analyze(Compiler.java:6361)
    at clojure.lang.Compiler.analyze(Compiler.java:6322)
    at clojure.lang.Compiler.eval(Compiler.java:6623)
    at clojure.lang.Compiler.load(Compiler.java:7064)
    at clojure.lang.RT.loadResourceScript(RT.java:370)
    at clojure.lang.RT.loadResourceScript(RT.java:361)
    at clojure.lang.RT.load(RT.java:440)
    at clojure.lang.RT.load(RT.java:411)
    at clojure.core$load$fn__5018.invoke(core.clj:5530)
    at clojure.core$load.doInvoke(core.clj:5529)
    at clojure.lang.RestFn.invoke(RestFn.java:408)
    at clojure.core$load_one.invoke(core.clj:5336)
    at clojure.core$load_lib$fn__4967.invoke(core.clj:5375)
    at clojure.core$load_lib.doInvoke(core.clj:5374)
    at clojure.lang.RestFn.applyTo(RestFn.java:142)
    at clojure.core$apply.invoke(core.clj:619)
    at clojure.core$load_libs.doInvoke(core.clj:5413)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.core$apply.invoke(core.clj:619)
    at clojure.core$require.doInvoke(core.clj:5496)
    at clojure.lang.RestFn.invoke(RestFn.java:457)
    at plumbing.core$eval11338$loading__4910__auto____11339.invoke(core.clj:1)
    at plumbing.core$eval11338.invoke(core.clj:1)
    at clojure.lang.Compiler.eval(Compiler.java:6619)
    at clojure.lang.Compiler.eval(Compiler.java:6608)
    at clojure.lang.Compiler.load(Compiler.java:7064)
    at clojure.lang.RT.loadResourceScript(RT.java:370)
    at clojure.lang.RT.loadResourceScript(RT.java:361)
    at clojure.lang.RT.load(RT.java:440)
    at clojure.lang.RT.load(RT.java:411)
    at clojure.core$load$fn__5018.invoke(core.clj:5530)
    at clojure.core$load.doInvoke(core.clj:5529)
    at clojure.lang.RestFn.invoke(RestFn.java:408)
    at clojure.core$load_one.invoke(core.clj:5336)
    at clojure.core$load_lib$fn__4967.invoke(core.clj:5375)
    at clojure.core$load_lib.doInvoke(core.clj:5374)
    at clojure.lang.RestFn.applyTo(RestFn.java:142)
    at clojure.core$apply.invoke(core.clj:619)
    at clojure.core$load_libs.doInvoke(core.clj:5413)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.core$apply.invoke(core.clj:619)
    at clojure.core$require.doInvoke(core.clj:5496)
    at clojure.lang.RestFn.invoke(RestFn.java:551)
    at puppetlabs.trapperkeeper.services$eval11240$loading__4910__auto____11241.invoke(services.clj:1)
    at puppetlabs.trapperkeeper.services$eval11240.invoke(services.clj:1)
    at clojure.lang.Compiler.eval(Compiler.java:6619)
    at clojure.lang.Compiler.eval(Compiler.java:6608)
    at clojure.lang.Compiler.load(Compiler.java:7064)
    at clojure.lang.RT.loadResourceScript(RT.java:370)
    at clojure.lang.RT.loadResourceScript(RT.java:361)
    at clojure.lang.RT.load(RT.java:440)
    at clojure.lang.RT.load(RT.java:411)
    at clojure.core$load$fn__5018.invoke(core.clj:5530)
    at clojure.core$load.doInvoke(core.clj:5529)
    at clojure.lang.RestFn.invoke(RestFn.java:408)
    at clojure.core$load_one.invoke(core.clj:5336)
    at clojure.core$load_lib$fn__4967.invoke(core.clj:5375)
    at clojure.core$load_lib.doInvoke(core.clj:5374)
    at clojure.lang.RestFn.applyTo(RestFn.java:142)
    at clojure.core$apply.invoke(core.clj:619)
    at clojure.core$load_libs.doInvoke(core.clj:5413)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.core$apply.invoke(core.clj:619)
    at clojure.core$require.doInvoke(core.clj:5496)
    at clojure.lang.RestFn.invoke(RestFn.java:703)
    at puppetlabs.trapperkeeper.core$eval11234$loading__4910__auto____11235.invoke(core.clj:1)
    at puppetlabs.trapperkeeper.core$eval11234.invoke(core.clj:1)
    at clojure.lang.Compiler.eval(Compiler.java:6619)
    at clojure.lang.Compiler.eval(Compiler.java:6608)
    at clojure.lang.Compiler.load(Compiler.java:7064)
    at clojure.lang.RT.loadResourceScript(RT.java:370)
    at clojure.lang.RT.loadResourceScript(RT.java:361)
    at clojure.lang.RT.load(RT.java:440)
    at clojure.lang.RT.load(RT.java:411)
    at clojure.core$load$fn__5018.invoke(core.clj:5530)
    at clojure.core$load.doInvoke(core.clj:5529)
    at clojure.lang.RestFn.invoke(RestFn.java:408)
    at clojure.core$load_one.invoke(core.clj:5336)
    at clojure.core$load_lib$fn__4967.invoke(core.clj:5375)
    at clojure.core$load_lib.doInvoke(core.clj:5374)
    at clojure.lang.RestFn.applyTo(RestFn.java:142)
    at clojure.core$apply.invoke(core.clj:619)
    at clojure.core$load_libs.doInvoke(core.clj:5413)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.core$apply.invoke(core.clj:619)
    at clojure.core$require.doInvoke(core.clj:5496)
    at clojure.lang.RestFn.invoke(RestFn.java:1789)
    at com.puppetlabs.puppetdb.cli.services$eval11228$loading__4910__auto____11229.invoke(services.clj:45)
```

when compiling. This PR fixed the problem for us. My guess is the problem is similar to cross compiling/potemkin issues found in schema and fixed in 0.2.0.
