### PR TITLE
Add defmemo

### DIFF
--- a/src/plumbing/core.clj
+++ b/src/plumbing/core.clj
@@ -319,6 +319,12 @@
              (swap! a# assoc args# v#)
              v#))))))
 
+(defmacro defmemo
+  "Like defn, but memoized (including recursive calls)."
+  [name args & body]
+  `(def ~name
+     (memoized-fn ~name ~args ~@body)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Miscellaneous
 

--- a/test/plumbing/core_test.clj
+++ b/test/plumbing/core_test.clj
@@ -282,6 +282,17 @@
             10)))
     (is (= 11 @calls))))
 
+(deftest defmemo-test
+  (let [calls (atom 0)]
+    (plumbing.core/defmemo factorial [x]
+      (swap! calls inc)
+      (if (zero? x) 1 (* x (factorial (dec x)))))
+    (is (= 120
+           (factorial 5)))
+    (is (= 24
+           (factorial 4)))
+    (is (= 6 @calls))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Miscellaneous
 


### PR DESCRIPTION
This seems easier to read (and less repetitive) than the old way. Compare:

``` clojure
(def fib (memoized-fn fib [x]
           ...))
```

with:

``` clojure
(defmemo fib [x]
  ...)
```
