### PR TITLE
Update ?> to receive one boolean fn

### DIFF
--- a/src/plumbing/core.cljx
+++ b/src/plumbing/core.cljx
@@ -295,7 +295,9 @@
   "Conditional single-arrow operation (-> m (?> add-kv? (assoc :k :v)))"
   [arg do-it? & rest]
   `(if ~do-it?
-     (-> ~arg ~@rest)
+     (if ~rest
+       (-> ~arg ~@rest)
+       (-> ~arg ~do-it?))
      ~arg))
 
 (defmacro fn->


### PR DESCRIPTION
This case works with all cases where we pass not null (false) fn, example `(-> f (?> middleware middleware) wrap-cookies)`

```
(let [the-fn #(assoc % :b :2)] 
   (-> {:a :1} (?> the-fn)))
```

=> {:a 1 :b 2}
