### PR TITLE
Change assert-iae to a function

### DIFF
--- a/src/plumbing/fnk/pfnk.cljx
+++ b/src/plumbing/fnk/pfnk.cljx
@@ -6,13 +6,11 @@
    are one possible example)."
   (:require
    [schema.core :as s]
-   [plumbing.fnk.schema :as schema]
-   #+clj [schema.macros :as sm]
-   #+clj [plumbing.fnk.schema :refer [assert-iae]])
+   [plumbing.fnk.schema :as schema :refer [assert-iae]]
+   #+clj [schema.macros :as sm])
   #+cljs
   (:require-macros
-   [schema.macros :as sm]
-   [plumbing.fnk.schema :refer [assert-iae]]))
+   [schema.macros :as sm]))
 
 #+clj (set! *warn-on-reflection* true)
 

--- a/src/plumbing/fnk/schema.cljx
+++ b/src/plumbing/fnk/schema.cljx
@@ -30,11 +30,11 @@
 
 ;;; Helpers
 
-(defmacro assert-iae
+(defn assert-iae
   "Like assert, but throws an IllegalArgumentException not an Error (and also takes args to format)"
-  [form & format-args]
-  `(when-not ~form (throw (#+clj IllegalArgumentException. #+cljs js/Error.
-                                 ^String (schema-utils/format* ~@format-args)))))
+  [value & format-args]
+  (when-not value (throw (#+clj IllegalArgumentException. #+cljs js/Error.
+                                ^String (apply schema-utils/format* format-args)))))
 
 (defn assert-distinct
   "Like (assert (distinct? things)) but with a more helpful error message."


### PR DESCRIPTION
`assert-iae` as a macro was breaking cljs assertions by always compiling the clj version within the macro.
