### PR TITLE
Bump to Schema 2.1.4 and its fixed cljs compilation detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.2
+ * Fix cljs compilation issue appearing in some circumstances (No such namespace: js)
+
 ## 0.3.1
  * Fix cljs issue where plumbing.fnk.schema was missing from dependency tree
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This first release includes our '[Graph](http://blog.getprismatic.com/prismatics
 
 *New in 0.2.0: support for schema.core/defn-style schemas on fnks and Graphs.  See `(doc fnk)` for details.*
 
-Leiningen dependency (Clojars): `[prismatic/plumbing "0.3.1"]`. [Latest API docs](http://prismatic.github.io/plumbing).
+Leiningen dependency (Clojars): `[prismatic/plumbing "0.3.2"]`. [Latest API docs](http://prismatic.github.io/plumbing).
 
 **This is an alpha release.  We  are using it internally in production, but the API and organizational structure are subject to change.  Comments and suggestions are much appreciated.**
 

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}
 
-  :dependencies [[prismatic/schema "0.2.3"]
+  :dependencies [[prismatic/schema "0.2.4"]
                  [de.kotka/lazymap "3.1.0" :exclusions [org.clojure/clojure]]]
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.5.1"]

--- a/src/plumbing/fnk/impl.clj
+++ b/src/plumbing/fnk/impl.clj
@@ -349,7 +349,7 @@
                         (schema/guess-expr-output-schema (last body))
                         explicit-output-schema)
         fn-name (vary-meta (or name? (gensym "fnk")) assoc :schema output-schema)]
-    (if (and (not (schema-macros/compiling-cljs?))
+    (if (and (not (schema-macros/cljs-env? env))
              (not-any? #{'& :as} bind)) ;; If we can make a positional fnk form, do it.
       (let [[bind-sym-map bound-body] (positional-arg-bind-syms-and-body env bind `(do ~@body))]
         (positional-fnk-form


### PR DESCRIPTION
Verified that this fixes 

https://github.com/Prismatic/plumbing/issues/42

when used in the example project.  See also

https://github.com/Prismatic/schema/pull/113.

(Please don't merge until schema is merged and the new version actually released)
