### PR TITLE
Correctly generate errors in ClojureScript client code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.3
+ * Properly generate cross-platform assertions, fixing ClojureScript errors that tried to throw Java errors.
+
 ## 0.3.2
  * Fix cljs compilation issue appearing in some circumstances (No such namespace: js)
 

--- a/src/plumbing/core.cljx
+++ b/src/plumbing/core.cljx
@@ -113,9 +113,7 @@
   [m k]
   (lazy-get
    m k
-   (let [e ^String (schema-utils/format* "Key %s not found in %s" k (mapv key m))]
-     (throw #+clj (IllegalArgumentException. e)
-            #+cljs (js/Error. e)))))
+   (schema/assert-iae false "Key %s not found in %s" k (mapv key m))))
 
 (defn safe-get-in
   "Like get-in but throws exception if not found"

--- a/src/plumbing/fnk/schema.cljx
+++ b/src/plumbing/fnk/schema.cljx
@@ -31,10 +31,10 @@
 ;;; Helpers
 
 (defmacro assert-iae
-  "Like assert, but throws an IllegalArgumentException not an Error (and also takes args to format)"
+  "Like assert, but throws a RuntimeException in Clojure (not an AssertionError),
+   and also takes args to format."
   [form & format-args]
-  `(when-not ~form (throw (#+clj IllegalArgumentException. #+cljs js/Error.
-                                 ^String (schema-utils/format* ~@format-args)))))
+  `(sm/assert! ~form ~@format-args))
 
 (defn assert-distinct
   "Like (assert (distinct? things)) but with a more helpful error message."

--- a/test/plumbing/fnk/schema_test.cljx
+++ b/test/plumbing/fnk/schema_test.cljx
@@ -11,7 +11,7 @@
 #+cljs
 (do
   (def Exception js/Error)
-  (def IllegalArgumentException js/Error))
+  (def RuntimeException js/Error))
 
 #+clj ;; the expression-munging doesn't play well with cljs.
 (deftest explicit-schema-key-map-test
@@ -96,15 +96,15 @@
          (fnk-schema/sequence-schemata
           [{:a s/Any} {:c s/Any}]
           [:o2 [{(s/optional-key :b) s/Any :c s/Any} {:o21 s/Any}]])))
-  (is (thrown? IllegalArgumentException
+  (is (thrown? RuntimeException
                (fnk-schema/sequence-schemata
                 [{:a s/Any} {:c s/Any}]
                 [:o2 [{(s/optional-key :b) s/Any :c s/Any :o2 s/Any} {:o21 s/Any}]])))
-  (is (thrown? IllegalArgumentException
+  (is (thrown? RuntimeException
                (fnk-schema/sequence-schemata
                 [{:a s/Any} {:c s/Any :o2 s/Any}]
                 [:o2 [{(s/optional-key :b) s/Any :c s/Any} {:o21 s/Any}]])))
-  (is (thrown? IllegalArgumentException
+  (is (thrown? RuntimeException
                (fnk-schema/sequence-schemata
                 [{:a s/Any :o2 s/Any} {:c s/Any}]
                 [:o2 [{(s/optional-key :b) s/Any :c s/Any} {:o21 s/Any}]]))))


### PR DESCRIPTION
- The previous approach tried to use cljx in a macro, which doesn't work
- Schema.macros has a correct approach based on checking the environment of the macro
- Use that approach; this incidentally changes IllegalArgumentExceptions to RuntimeExceptions,
  but doesn't seem like a big deal.

@cpetzold @loganlinn @robert-stuttaford please take a look, and see if this fixes the issues you've been seeing.

See also: https://github.com/Prismatic/schema/issues/121
