### PR TITLE
Change keyword lookup to work with records

### DIFF
--- a/src/plumbing/core.cljx
+++ b/src/plumbing/core.cljx
@@ -80,7 +80,7 @@
    (including at the top-level)."
   [m [k & ks]]
   (when m
-    (if-let [res (and ks (dissoc-in (m k) ks))]
+    (if-let [res (and ks (dissoc-in (get m k) ks))]
       (assoc m k res)
       (let [res (dissoc m k)]
         (when-not (empty? res)


### PR DESCRIPTION
dissoc-in fails with 

```
ClassCastException my.namespace.MyRecord cannot be cast to clojure.lang.IFn  
```

when called with a record. This is because records don't implement IFn and can't look themselves up given a key. Adding a get will allow dissoc-in to work with records.
