### PR TITLE
exclude clojure.core/update

### DIFF
--- a/src/plumbing/core.cljx
+++ b/src/plumbing/core.cljx
@@ -8,7 +8,6 @@
    #+clj [schema.macros :as sm]
    [plumbing.fnk.schema :as schema]
    #+clj [plumbing.fnk.impl :as fnk-impl])
-  #+clj
   (:refer-clojure :exclude [update]))
 
 #+clj (set! *warn-on-reflection* true)


### PR DESCRIPTION
avoid warning in clojure 1.7
