### PR TITLE
Async optional fixes

### DIFF
--- a/src/plumbing/graph_async.cljx
+++ b/src/plumbing/graph_async.cljx
@@ -45,7 +45,7 @@
           req-ks (schema/required-toplevel-keys (pfnk/input-schema g))
           edges (concat
                  (for [[k v] g
-                       parent-k (filter g (keys (pfnk/input-schema v)))]
+                       parent-k (filter g (pfnk/input-schema-keys v))]
                    [parent-k k])
                  (for [k (keys g)]
                    [k ::done]))

--- a/test/plumbing/graph_async_test.cljx
+++ b/test/plumbing/graph_async_test.cljx
@@ -16,9 +16,10 @@
                  :a2 (plumbing/fnk [x] (go (<! (async/timeout 100)) (- x 10)))}
              :b (plumbing/fnk [[:a a1]] (* a1 2))
              :c (plumbing/fnk [[:a a2]] (* a2 2))
-             :d (plumbing/fnk [{y 2}] (* y y))})
+             :d (plumbing/fnk [{y 2}] (* y y))
+             :e (plumbing/fnk [{d 9}] (+ d 90))})
            {:x 1 :y 7})
-        expected-result {:a {:a1 2 :a2 -9} :b 4 :c -18 :d 49}]
+        expected-result {:a {:a1 2 :a2 -9} :b 4 :c -18 :d 49 :e 139}]
     #+clj (is (= expected-result
                  (async/<!! c)))
     #+cljs (go


### PR DESCRIPTION
This fixes and tests that `async-compile` respects optional inputs and computed nodes.
