### PR TITLE
Rewrite the jvm distinct-by to use a transient set

### DIFF
--- a/src/plumbing/core.cljx
+++ b/src/plumbing/core.cljx
@@ -239,12 +239,15 @@
    values according to f. If multiple elements of xs return the same
    value under f, the first is returned"
   [f xs]
-  #+clj  (let [s (java.util.HashSet.)]
-           (for [x xs
-                 :let [id (f x)]
-                 :when (not (.contains s id))]
-             (do (.add s id)
-                 x)))
+  #+clj ((fn self [^clojure.lang.ITransientSet s xs]
+           (lazy-seq
+            (when-let [[x & more] (seq xs)]
+              (let [id (f x)]
+                (if (.contains s id)
+                  (self s more)
+                  (cons x (self (conj! s id) more)))))))
+         (transient #{})
+         xs)
   #+cljs (let [s (atom #{})]
            (for [x xs
                  :let [id (f x)]


### PR DESCRIPTION
This means we don't need to add the equality warning that distinct-fast
and frequencies-fast have.

Had to restructure the code for tracking return values since punching
transients violates the transient contract.

When I run tests locally there's an unrelated-looking test that fails, so
I'm crossing my fingers and hoping it's actually unrelated. The new code
works fine in my repl.

It seemed weird to have to use interop to check if the id exists, but there
seems to be no other way to query a transient set.