### PR TITLE
Remove efficient Clojure version of distinct-by:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.1 
+ * Fix concurrency issue recently introduced in distinct-by in Clojure (sequence had to be realized in creator thread due to transient restrictions)
+
 ## 0.4.0
  * **Breaking** Bump dependencies, potemkin no longer included transitively through schema.  
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This first release includes our '[Graph](http://blog.getprismatic.com/prismatics
 
 *New in 0.2.0: support for schema.core/defn-style schemas on fnks and Graphs.  See `(doc fnk)` for details.*
 
-Leiningen dependency (Clojars): `[prismatic/plumbing "0.4.0"]`. [Latest API docs](http://prismatic.github.io/plumbing).
+Leiningen dependency (Clojars): `[prismatic/plumbing "0.4.1"]`. [Latest API docs](http://prismatic.github.io/plumbing).
 
 **This is an alpha release.  We  are using it internally in production, but the API and organizational structure are subject to change.  Comments and suggestions are much appreciated.**
 

--- a/src/plumbing/core.cljx
+++ b/src/plumbing/core.cljx
@@ -239,21 +239,12 @@
    values according to f. If multiple elements of xs return the same
    value under f, the first is returned"
   [f xs]
-  #+clj ((fn self [^clojure.lang.ITransientSet s xs]
-           (lazy-seq
-            (when-let [[x & more] (seq xs)]
-              (let [id (f x)]
-                (if (.contains s id)
-                  (self s more)
-                  (cons x (self (conj! s id) more)))))))
-         (transient #{})
-         xs)
-  #+cljs (let [s (atom #{})]
-           (for [x xs
-                 :let [id (f x)]
-                 :when (not (contains? @s id))]
-             (do (swap! s conj id)
-                 x))))
+  (let [s (atom #{})]
+    (for [x xs
+          :let [id (f x)]
+          :when (not (contains? @s id))]
+      (do (swap! s conj id)
+          x))))
 
 #+clj
 (defn distinct-id


### PR DESCRIPTION
 -  works around transient thread sharing issue introduced in #81
 -  efficient implementation is possible in Clojure 1.7, so can be added back later.

cc @trillioneyes @davegolland