### PR TITLE
Fix 'update' warnings under Clojure 1.7 (fixes #93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.4.2
  * Letk now supports simple symbol bindings as well as map destructuring bindings.
+ * Fix *update* warnings under Clojure 1.7.
 
 ## 0.4.1 
  * Fix concurrency issue recently introduced in distinct-by in Clojure (sequence had to be realized in creator thread due to transient restrictions)

--- a/src/plumbing/core.cljx
+++ b/src/plumbing/core.cljx
@@ -3,10 +3,10 @@
   #+cljs
   (:require-macros
    [plumbing.core :refer [for-map lazy-get -unless-update]]
-   [schema.macros :refer [if-cljs]])
+   [schema.macros :as schema-macros])
   (:require
    [schema.utils :as schema-utils]
-   #+clj [schema.macros :as schema-macros :refer [if-cljs]]
+   #+clj [schema.macros :as schema-macros]
    [plumbing.fnk.schema :as schema :include-macros true]
    #+clj [plumbing.fnk.impl :as fnk-impl]))
 
@@ -42,12 +42,13 @@
   "Execute and yield body only if Clojure version preceeds introduction
   of 'update' into core namespace."
   [body]
-  `(if-cljs ~body
-            (when (pos? (compare
-                         [1 7 0]
-                         (mapv #(get *clojure-version* %)
-                               [:major :minor :incremental])))
-              ~body)))
+  `(schema-macros/if-cljs
+    ~body
+    ~(when (pos? (compare
+                  [1 7 0]
+                  (mapv #(get *clojure-version* %)
+                        [:major :minor :incremental])))
+       body)))
 
 (-unless-update
  (defn update


### PR DESCRIPTION
Fixes `update` to apply the conditional at macroexpansion time as intended.

Also updates the `ns` declarations to match style.