### PR TITLE
Remove warning about overriding update

### DIFF
--- a/src/plumbing/core.cljx
+++ b/src/plumbing/core.cljx
@@ -8,7 +8,8 @@
    [schema.utils :as schema-utils]
    #+clj [schema.macros :as schema-macros]
    [plumbing.fnk.schema :as schema :include-macros true]
-   #+clj [plumbing.fnk.impl :as fnk-impl]))
+   #+clj [plumbing.fnk.impl :as fnk-impl])
+  (:refer-clojure :exclude [update]))
 
 #+clj (set! *warn-on-reflection* true)
 


### PR DESCRIPTION
I know you guys had hard time about trying to properly exclude update (#76, #78, #93, #94). But this warning is really annoying:

```
WARNING: update already refers to: cljs.core/update being replaced by: plumbing.core/update at line 54 /Users/prokopov/.boot/tmp/Users/prokopov/Dropbox/ws/cognician/c3/bkh/-2cctky/out/plumbing/core.cljs
```

and I still get it under 0.4.2 when using ClojureScript.

And I was thinking: it’s not bad to have `update` defined twice per se (it’s still namespaced), but it’s warning that gets in the way. So why we just always define it but remove the warning (via `(:refer-clojure :exclude [update])`—works for both clj and cljs). We get additional bonus: if somebody was using your version, his code would keep working. And looks like nothing bad happens... Right?