### PR TITLE
Exclude update from core.cljx to avoid cljs warnings (thanks @tonsky)

### DIFF
--- a/src/plumbing/core.cljx
+++ b/src/plumbing/core.cljx
@@ -1,5 +1,6 @@
 (ns plumbing.core
   "Utility belt for Clojure in the wild"
+  (:refer-clojure :exclude [update])
   #+cljs
   (:require-macros
    [plumbing.core :refer [for-map lazy-get -unless-update]]


### PR DESCRIPTION
Replaces #96.