### PR TITLE
Attach default values as metadata on optional key schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.1
+ * (Experimental) include default values as metadata on fnk schemas.
+
 ## 0.5.0
  * **BREAKING**: Bump to Schema 1.0.1, breaking compatibility with pre-1.0.0 Schema.
 

--- a/src/plumbing/fnk/impl.clj
+++ b/src/plumbing/fnk/impl.clj
@@ -92,7 +92,7 @@
           (assert-unschematized binding)
           (schema/assert-iae (= 1 (count schema-fixed-binding))
                              "optional binding has more than 1 entry: %s" schema-fixed-binding)
-          {:schema-entry [`(s/optional-key ~bound-key) (schema-macros/extract-schema-form bound-sym)]
+          {:schema-entry [`(with-meta (s/optional-key ~bound-key) {:default ~opt-val-expr}) (schema-macros/extract-schema-form bound-sym)]
            :body-form `(let [~(name-sym bound-sym) (get ~map-sym ~bound-key ~opt-val-expr)]
                          ~body-form)})
 

--- a/src/plumbing/fnk/schema.cljx
+++ b/src/plumbing/fnk/schema.cljx
@@ -86,7 +86,11 @@
         ;; Deal with `(s/optional-key k) form from impl
         (and (sequential? k) (not (vector? k)) (= (count k) 2)
              (= (first k) 'schema.core/optional-key))
-        [(second k) false]))
+        [(second k) false]
+
+        ;; Deal with `(with-meta ...) form from impl
+        (and (sequential? k) (not (vector? k)) (= (name (first k)) 'with-meta))
+        (unwrap-schema-form-key (second k))))
 
 (s/defn explicit-schema-key-map :- {s/Keyword s/Bool}
   "Given a possibly-unevaluated map schema, return a map from bare keyword to true

--- a/test/plumbing/core_test.cljx
+++ b/test/plumbing/core_test.cljx
@@ -503,7 +503,16 @@
       (is (= {:a s/Str :b {:c s/Str} s/Keyword s/Any} (pfnk/input-schema f)))
       (is (= ["1" "2"] (f {:a "1" :b {:c "2"}})))
       (is (thrown? Exception (f {:a "1" :b {:c 2}})))
-      (is (thrown? Exception (f {:a "1" :b {:c "2" :d "3"}}))))))
+      (is (thrown? Exception (f {:a "1" :b {:c "2" :d "3"}})))))
+
+  (testing "default values"
+    (is (= {:default "foo"}
+           (-> (p/fnk [{a :- s/Str "foo"}])
+               pfnk/input-schema
+               (dissoc s/Keyword)
+               keys
+               first
+               meta)))))
 
 (deftest fnk-qualified-key-test
   (is (= [1 2 3] ((p/fnk [a/b b/c c/d] [b c d]) {:a/b 1 :b/c 2 :c/d 3})))


### PR DESCRIPTION
Context is here: 
https://groups.google.com/forum/#!topic/prismatic-plumbing/NWUnqbYhfac

These default values can now be extracted and used with coercion, etc if desired.  They are in metadata to avoid breaking existing code, and should be considered experimental for now.  