### PR TITLE
Fix broken cycle check in cljs topological sort (fixes #109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.2
+ * Fix broken cycle check in Clojurescript topological sort.
+
 ## 0.5.1
  * (Experimental) include default values as metadata on fnk schemas.
 


### PR DESCRIPTION
Replaces #110.

Rather than put back the old, slower implementation, I just copied the Clojure implementation but used atoms of normal Clojure types. 